### PR TITLE
Feat : input 컴포넌트 제작

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3001,6 +3001,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lottie-react": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lottie-react/-/lottie-react-2.4.1.tgz",
@@ -3019,17 +3030,6 @@
       "resolved": "https://registry.npmjs.org/lottie-web/-/lottie-web-5.12.2.tgz",
       "integrity": "sha512-uvhvYPC8kGPjXT3MyKMrL3JitEAmDMp30lVkuq/590Mw9ok6pWcFCwXJveo0t5uqYw1UREQHofD+jVpdjBv8wg==",
       "license": "MIT"
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -3438,6 +3438,7 @@
       "version": "16.3.0",
       "resolved": "https://registry.npmjs.org/react-svg/-/react-svg-16.3.0.tgz",
       "integrity": "sha512-MvoQbITgkmpPJYwDTNdiUyoncJFfoa0D86WzoZuMQ9c/ORJURPR6rPMnXDsLOWDCAyXuV9nKZhQhGyP0HZ0MVQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@tanem/svg-injector": "^10.1.68",

--- a/src/pages/guide/Guide.tsx
+++ b/src/pages/guide/Guide.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import Modal from "@/shared/component/Modal";
 import cancel from "@/assets/images/cancel.svg";
 import Button from "@/shared/component/Button";
+import CommonInput from "@/shared/component/input";
 
 const Guide = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -67,6 +68,36 @@ const Guide = () => {
           message="해당 영상을 정말 삭제하시겠습니까?"
           leftButtonText="취소"
           rightButtonText="삭제하기"
+        />
+        <CommonInput
+          label="플레이리스트 제목"
+          size="xxlarge"
+          placeholder="제목을 입력해주세요"
+        />
+
+        <CommonInput
+          label="동영상 추가"
+          size="large"
+          placeholder="링크를 입력해주세요"
+        />
+
+        <CommonInput size="medium" placeholder="검색어를 입력해주세요" />
+
+        <CommonInput size="xlarge" placeholder="이름을 입력해주세요" />
+
+        <CommonInput
+          label="닉네임"
+          labelPosition="left"
+          size="small"
+          placeholder="닉네임을 입력해주세요"
+        />
+
+        <CommonInput
+          label="관심 아티스트"
+          labelPosition="left"
+          size="small"
+          isTextarea
+          placeholder="좋아하는 아티스트를 입력해주세요"
         />
       </div>
     </>

--- a/src/pages/guide/Guide.tsx
+++ b/src/pages/guide/Guide.tsx
@@ -70,22 +70,33 @@ const Guide = () => {
           rightButtonText="삭제하기"
         />
         <CommonInput
+          id="playlistTitle"
           label="플레이리스트 제목"
           placeholder="제목을 입력해주세요"
           width="488px"
         />
 
         <CommonInput
+          id="videoUrl"
           label="동영상 추가"
           placeholder="링크를 입력해주세요"
           width="468px"
         />
 
-        <CommonInput placeholder="이름을 입력해주세요" width="468px" />
-
-        <CommonInput placeholder="검색어를 입력해주세요" width="318px" />
+        <CommonInput
+          id="userName"
+          placeholder="이름을 입력해주세요"
+          width="468px"
+        />
 
         <CommonInput
+          id="search"
+          placeholder="검색어를 입력해주세요"
+          width="318px"
+        />
+
+        <CommonInput
+          id="nickname"
           label="닉네임"
           labelPosition="left"
           placeholder="닉네임을 입력해주세요"
@@ -93,6 +104,7 @@ const Guide = () => {
         />
 
         <CommonInput
+          id="artist"
           label="관심 아티스트"
           labelPosition="left"
           isTextarea

--- a/src/pages/guide/Guide.tsx
+++ b/src/pages/guide/Guide.tsx
@@ -71,33 +71,33 @@ const Guide = () => {
         />
         <CommonInput
           label="플레이리스트 제목"
-          size="xxlarge"
           placeholder="제목을 입력해주세요"
+          width="488px"
         />
 
         <CommonInput
           label="동영상 추가"
-          size="large"
           placeholder="링크를 입력해주세요"
+          width="468px"
         />
 
-        <CommonInput size="medium" placeholder="검색어를 입력해주세요" />
+        <CommonInput placeholder="이름을 입력해주세요" width="468px" />
 
-        <CommonInput size="xlarge" placeholder="이름을 입력해주세요" />
+        <CommonInput placeholder="검색어를 입력해주세요" width="318px" />
 
         <CommonInput
           label="닉네임"
           labelPosition="left"
-          size="small"
           placeholder="닉네임을 입력해주세요"
+          width="218px"
         />
 
         <CommonInput
           label="관심 아티스트"
           labelPosition="left"
-          size="small"
           isTextarea
           placeholder="좋아하는 아티스트를 입력해주세요"
+          width="250px"
         />
       </div>
     </>

--- a/src/pages/guide/Guide.tsx
+++ b/src/pages/guide/Guide.tsx
@@ -96,7 +96,7 @@ const Guide = () => {
           label="관심 아티스트"
           labelPosition="left"
           isTextarea
-          placeholder="좋아하는 아티스트를 입력해주세요"
+          placeholder="관심 아티스트를 입력해주세요"
           width="250px"
         />
       </div>

--- a/src/shared/component/input.tsx
+++ b/src/shared/component/input.tsx
@@ -1,0 +1,132 @@
+import React from "react";
+import styled from "@emotion/styled";
+
+type LabelPosition = "top" | "left";
+type InputSize = "xxlarge" | "xlarge" | "large" | "medium" | "small";
+
+interface InputProps {
+  label?: string;
+  labelPosition?: LabelPosition;
+  placeholder?: string;
+  size?: InputSize;
+  isTextarea?: boolean;
+  value?: string;
+  onChange?: (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => void;
+}
+
+const sizeMap: Record<InputSize, string> = {
+  xxlarge: "488px",
+  xlarge: "468px",
+  large: "438px",
+  medium: "318px",
+  small: "250px",
+};
+
+const CommonInput = ({
+  label,
+  labelPosition = "top",
+  placeholder = "",
+  size = "small",
+  isTextarea = false,
+  value,
+  onChange,
+}: InputProps) => {
+  const width = sizeMap[size];
+
+  return (
+    <Wrapper
+      labelPosition={labelPosition}
+      width={width}
+      isTextarea={isTextarea}
+    >
+      {label && <Label labelPosition={labelPosition}>{label}</Label>}
+      {isTextarea ? (
+        <TextArea placeholder={placeholder} value={value} onChange={onChange} />
+      ) : (
+        <Input
+          placeholder={placeholder}
+          value={value}
+          onChange={onChange}
+          labelPosition={labelPosition}
+        />
+      )}
+    </Wrapper>
+  );
+};
+
+export default CommonInput;
+
+interface WrapperProps {
+  labelPosition: LabelPosition;
+  width: string;
+  isTextarea: boolean;
+}
+
+const Wrapper = styled.div<WrapperProps>`
+  display: flex;
+  flex-direction: ${({ labelPosition }) =>
+    labelPosition === "top" ? "column" : "row"};
+  align-items: ${({ labelPosition, isTextarea }) =>
+    labelPosition === "top"
+      ? "flex-start"
+      : isTextarea
+        ? "flex-start"
+        : "center"};
+  gap: ${({ labelPosition }) => (labelPosition === "left" ? "50px" : "12px")};
+  width: ${({ labelPosition, width }) =>
+    labelPosition === "left" ? "auto" : width};
+`;
+
+const Label = styled.label<{ labelPosition: LabelPosition }>`
+  font-weight: bold;
+  font-size: var(--font-size-large);
+  color: var(--text-primary);
+  min-width: ${({ labelPosition }) =>
+    labelPosition === "left" ? "110px" : "auto"};
+  text-align: ${({ labelPosition }) =>
+    labelPosition === "left" ? "right" : "initial"};
+`;
+
+const Input = styled.input<{ labelPosition: LabelPosition }>`
+  height: 38px;
+  width: ${({ labelPosition }) =>
+    labelPosition === "left" ? "218px" : "100%"};
+  border: 1px solid var(--disabled);
+  border-radius: 20px;
+  background-color: var(--background-color);
+  padding: 0 15px;
+  font-size: var(--font-size-primary);
+  color: var(--text-primary);
+
+  &:focus {
+    border: 2px solid var(--primary);
+  }
+
+  &::placeholder {
+    color: var(--disabled);
+    font-size: var(--font-size-primary);
+  }
+`;
+
+const TextArea = styled.textarea`
+  height: 58px;
+  width: 228px;
+  border: 1px solid var(--disabled);
+  border-radius: 20px;
+  background-color: var(--background-color);
+  padding: 10px 10px;
+  font-size: var(--font-size-primary);
+  color: var(--text-primary);
+  resize: none;
+
+  &:focus {
+    border: 2px solid var(--primary);
+  }
+
+  &::placeholder {
+    color: var(--disabled);
+    font-size: var(--font-size-primary);
+  }
+`;

--- a/src/shared/component/input.tsx
+++ b/src/shared/component/input.tsx
@@ -106,7 +106,7 @@ const TextArea = styled.textarea<{ width?: string }>`
   border: 1px solid var(--disabled);
   border-radius: 20px;
   background-color: var(--background-color);
-  padding: 10px 10px;
+  padding: 10px;
   font-size: var(--font-size-primary);
   color: var(--text-primary);
   resize: none;

--- a/src/shared/component/input.tsx
+++ b/src/shared/component/input.tsx
@@ -2,13 +2,12 @@ import React from "react";
 import styled from "@emotion/styled";
 
 type LabelPosition = "top" | "left";
-type InputSize = "xxlarge" | "xlarge" | "large" | "medium" | "small";
 
 interface InputProps {
   label?: string;
   labelPosition?: LabelPosition;
   placeholder?: string;
-  size?: InputSize;
+  width?: string;
   isTextarea?: boolean;
   value?: string;
   onChange?: (
@@ -16,25 +15,15 @@ interface InputProps {
   ) => void;
 }
 
-const sizeMap: Record<InputSize, string> = {
-  xxlarge: "488px",
-  xlarge: "468px",
-  large: "438px",
-  medium: "318px",
-  small: "250px",
-};
-
 const CommonInput = ({
   label,
   labelPosition = "top",
   placeholder = "",
-  size = "small",
+  width = "250px",
   isTextarea = false,
   value,
   onChange,
 }: InputProps) => {
-  const width = sizeMap[size];
-
   return (
     <Wrapper
       labelPosition={labelPosition}
@@ -50,6 +39,7 @@ const CommonInput = ({
           value={value}
           onChange={onChange}
           labelPosition={labelPosition}
+          width={width}
         />
       )}
     </Wrapper>
@@ -89,10 +79,10 @@ const Label = styled.label<{ labelPosition: LabelPosition }>`
     labelPosition === "left" ? "right" : "initial"};
 `;
 
-const Input = styled.input<{ labelPosition: LabelPosition }>`
+const Input = styled.input<{ labelPosition: LabelPosition; width: string }>`
   height: 38px;
-  width: ${({ labelPosition }) =>
-    labelPosition === "left" ? "218px" : "100%"};
+  width: ${({ labelPosition, width }) =>
+    labelPosition === "left" ? width : "100%"};
   border: 1px solid var(--disabled);
   border-radius: 20px;
   background-color: var(--background-color);
@@ -110,9 +100,9 @@ const Input = styled.input<{ labelPosition: LabelPosition }>`
   }
 `;
 
-const TextArea = styled.textarea`
+const TextArea = styled.textarea<{ width?: string }>`
   height: 58px;
-  width: 228px;
+  width: ${({ width }) => width ?? "228px"};
   border: 1px solid var(--disabled);
   border-radius: 20px;
   background-color: var(--background-color);

--- a/src/shared/component/input.tsx
+++ b/src/shared/component/input.tsx
@@ -4,6 +4,7 @@ import styled from "@emotion/styled";
 type LabelPosition = "top" | "left";
 
 interface InputProps {
+  id?: string;
   label?: string;
   labelPosition?: LabelPosition;
   placeholder?: string;
@@ -16,6 +17,7 @@ interface InputProps {
 }
 
 const CommonInput = ({
+  id,
   label,
   labelPosition = "top",
   placeholder = "",
@@ -30,11 +32,21 @@ const CommonInput = ({
       width={width}
       isTextarea={isTextarea}
     >
-      {label && <Label labelPosition={labelPosition}>{label}</Label>}
+      {label && (
+        <Label htmlFor={id} labelPosition={labelPosition}>
+          {label}
+        </Label>
+      )}
       {isTextarea ? (
-        <TextArea placeholder={placeholder} value={value} onChange={onChange} />
+        <TextArea
+          id={id}
+          placeholder={placeholder}
+          value={value}
+          onChange={onChange}
+        />
       ) : (
         <Input
+          id={id}
           placeholder={placeholder}
           value={value}
           onChange={onChange}


### PR DESCRIPTION
## ✨ Related Issues

- 이슈 넘버 #3 

## 📝 Task Details

- Input 컴포넌트 구현
- labelPosition에 따라 label이 위(top) 또는 옆(left)에 위치하도록 구현
- width값을 props로 직접 받아서 유연하게 크기 조정 가능
- input & textarea 클릭 시에 primary 컬러로 지정

## 📂 References

![image](https://github.com/user-attachments/assets/7c9b7146-f173-4e93-999e-74fb70ecb6c1)

## 💖 Review Requirements

- `input & textarea 클릭 시에 primary 컬러로 지정` 은 사전에 얘기된 부분은 아니지만 input이 클릭됐을 때(작성중일 때) 활성화 되는 느낌이 들었으면 좋겠어서 추가해봤습니다! 어떠신가요?
- figma 상에서는 placeholder가 15px인 경우도, 16px인 경우도 있어서 16px로 통일한 상태입니다!
- guide에 작성된 width값들은 내부 여백과 border 값 포함해서 figma와 동일한 사이즈로 맞춰뒀습니다! 